### PR TITLE
Restore purple header color, orange and white text was failing google accessiblity tests

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -29,7 +29,7 @@ export default class MyDocument extends Document {
             }
 
             :root {
-              --navbar: #f7b731;
+              --navbar: #673AB7;
               --navbarTextColor: #fff;
               --navbarHeight: 56px;
               --toolbarHeight: 44px;

--- a/stories/base.css
+++ b/stories/base.css
@@ -1,5 +1,5 @@
 :root {
-  --navbar: #f7b731;
+  --navbar: #673ab7;
   --navbarTextColor: #fff;
   --navbarHeight: 56px;
   --toolbarHeight: 44px;


### PR DESCRIPTION
<img width="483" alt="Screen Shot 2019-04-30 at 1 15 58 am" src="https://user-images.githubusercontent.com/21725/56906415-88ff5280-6ae5-11e9-939d-71aacd6d0a68.png">
